### PR TITLE
Treat and log exception when trying to add a Private Key.

### DIFF
--- a/src/main/java/com/meetme/plugins/jira/gerrit/adminui/AdminServlet.java
+++ b/src/main/java/com/meetme/plugins/jira/gerrit/adminui/AdminServlet.java
@@ -184,7 +184,17 @@ public class AdminServlet extends HttpServlet {
                     dataDir.mkdirs();
                 }
 
-                privateKeyPath = File.createTempFile(configurationManager.getSshHostname(), ".key", dataDir);
+                String tempFilePrefix = configurationManager.getSshHostname();
+                String tempFileSuffix = ".key";
+
+                try {
+                    privateKeyPath = File.createTempFile(tempFilePrefix, tempFileSuffix, dataDir);
+                }
+                catch (IOException e) {
+                    log.info("---- Cannot create temporary file: " + e.getMessage() + ": " + dataDir.toString() + tempFilePrefix + tempFileSuffix + " ----");
+                    break;
+                }
+
                 privateKeyPath.setReadable(false, false);
                 privateKeyPath.setReadable(true, true);
 


### PR DESCRIPTION
In case of a misconfigured app-data file system level access permissions
it'll throw an unreadable exception stack trace to the browser screen.

This change makes it fail gracefully and add a meaningful message with
details to the log.