### PR TITLE
Branch column added to left panel

### DIFF
--- a/src/main/resources/templates/gerrit-reviews-left-panel.vm
+++ b/src/main/resources/templates/gerrit-reviews-left-panel.vm
@@ -65,6 +65,10 @@ limitations under the License.
             <a href="$change.url" title="$change.subject" target="gerrit-review-$change.number,$change.patchSet.number">$change.subject</a>
         </td>
 
+        <td class="nav gerrit-branch">
+            $change.branch
+        </td>
+
         <td class="nav gerrit-project">
             $change.project
         </td>
@@ -117,6 +121,7 @@ limitations under the License.
             <tr>
                 <th>#</th>
                 <th>Subject</th>
+                <th>Branch</th>
                 <th>Project</th>
                 <th>Status</th>
                 <th title="$i18n.getText('gerrit.tabpanel.most_significant_score')">CR</th>


### PR DESCRIPTION
My colleagues asked me to add column "Branch" to the left panel of your plugin. I did and it looks like this:
![Image](http://i.imgur.com/wG9vz7B.png)

Please pull this change to your repo if you think this is a good change. We find it very useful.

Thanks!