### PR TITLE
#51 Updating Jsch Dependency to Enable Modern SSH Cipher Suites

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,19 @@
             <!-- Using this for gerrit integration -->
             <groupId>com.sonyericsson.hudson.plugins.gerrit</groupId>
             <artifactId>gerrit-events</artifactId>
-            <version>1.5.2</version>
+            <version>1.99.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.jcraft</groupId>
+                    <artifactId>jsch</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <!-- Using this for ssh -->
+            <groupId>com.jcraft</groupId>
+            <artifactId>jsch</artifactId>
+            <version>0.1.54</version>
         </dependency>
         <dependency>
             <groupId>commons-fileupload</groupId>


### PR DESCRIPTION
    #51 Updating Jsch Dependency to Enable Modern SSH Cipher Suites

    - gerrit-events updated to v1.99.1
    - jsch updated to v1.54