### PR TITLE
Fix rendering of side panel

### DIFF
--- a/src/main/resources/styles/gerrit-reviews-tabpanel.css
+++ b/src/main/resources/styles/gerrit-reviews-tabpanel.css
@@ -87,6 +87,7 @@ span.gerrit-no-reviews
 {
   text-indent: 9999px;
   vertical-align: middle;
+  overflow: hidden;
 }
 
 #gerrit-reviews-side-panel span.twixi


### PR DESCRIPTION
Text for screen readers was missing "overflow: hidden;" property and was
thus rendered 9999px to the right.

fixes #45