### PR TITLE
Remove hard-coded Gerrit statuses

### DIFF
--- a/src/main/java/com/meetme/plugins/jira/gerrit/data/dto/GerritChange.java
+++ b/src/main/java/com/meetme/plugins/jira/gerrit/data/dto/GerritChange.java
@@ -28,21 +28,13 @@ import static com.meetme.plugins.jira.gerrit.tabpanel.GerritEventKeys.LAST_UPDAT
  */
 public class GerritChange extends Change implements Comparable<GerritChange> {
 
-    /**
-     * Gerrit review status enumeration, corresponding to the status string in the Gerrit change
-     * payload.
-     */
-    public static enum Status {
-        NEW, SUBMITTED, DRAFT, MERGED, ABANDONED
-    }
-
     private Date lastUpdated;
 
     private GerritPatchSet patchSet;
 
     private boolean isOpen;
 
-    private Status status;
+    private String status;
 
     public GerritChange() {
         super();
@@ -87,7 +79,7 @@ public class GerritChange extends Change implements Comparable<GerritChange> {
         }
 
         if (json.containsKey(GerritEventKeys.STATUS)) {
-            this.setStatus(Status.valueOf(json.getString(GerritEventKeys.STATUS)));
+            this.setStatus(json.getString(GerritEventKeys.STATUS));
         }
 
         this.isOpen = json.getBoolean(GerritEventKeys.OPEN);
@@ -101,7 +93,7 @@ public class GerritChange extends Change implements Comparable<GerritChange> {
         return patchSet;
     }
 
-    public Status getStatus() {
+    public String getStatus() {
         return status;
     }
 
@@ -121,7 +113,7 @@ public class GerritChange extends Change implements Comparable<GerritChange> {
         this.patchSet = patchSet;
     }
 
-    public void setStatus(Status status) {
+    public void setStatus(String status) {
         this.status = status;
     }
 }


### PR DESCRIPTION
The statuses can be extended via Gerrit plugins, in which case we
would throw an exception and fail to show any changes for the issue.

```
java.lang.IllegalArgumentException: No enum constant com.meetme.plugins.jira.gerrit.data.dto.GerritChange.Status.INTEGRATING
	at java.lang.Enum.valueOf(Enum.java:238)
	at com.meetme.plugins.jira.gerrit.data.dto.GerritChange$Status.valueOf(GerritChange.java:35)
	at com.meetme.plugins.jira.gerrit.data.dto.GerritChange.fromJson(GerritChange.java:90)
	at com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Change.<init>(Change.java:97)
	at com.meetme.plugins.jira.gerrit.data.dto.GerritChange.<init>(GerritChange.java:52)
	at com.meetme.plugins.jira.gerrit.data.IssueReviewsImpl.getReviewsFromGerrit(IssueRev
```

There's no need to hard-code these statuses as enums, as the rest
of the plugin operates on them as strings anyways.

Fixes #44 
